### PR TITLE
Fix event height

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -47,7 +47,7 @@ class DateContentRow extends React.Component {
 
   getRowLimit() {
     /* Guessing this only gets called on the dummyRow */
-    const eventHeight = getHeight(this.eventRowRef.current)
+    const eventHeight = getHeight(this.eventRowRef.current, true)
     const headingHeight = this.headingRowRef?.current
       ? getHeight(this.headingRowRef.current)
       : 0
@@ -181,7 +181,11 @@ class DateContentRow extends React.Component {
             </div>
           )}
           <ScrollableWeekComponent>
-            <WeekWrapper isAllDay={isAllDay} {...eventRowProps} rtl={this.props.rtl}>
+            <WeekWrapper
+              isAllDay={isAllDay}
+              {...eventRowProps}
+              rtl={this.props.rtl}
+            >
               {levels.map((segs, idx) => (
                 <EventRow key={idx} segments={segs} {...eventRowProps} />
               ))}


### PR DESCRIPTION
This PR fixes an issue with event height calculation. Previously, the getHeight function did not include margins (marginTop and marginBottom), which caused incorrect height calculations in some cases, leading to misaligned or overlapping events.

To fix this, the true parameter was added to getHeight, ensuring that the computed height includes external margins.

